### PR TITLE
fix: соблюсти Layout/SpaceInsideArrayLiteralBrackets (#8)

### DIFF
--- a/docs/features/008-fix-rubocop-array-brackets/brief.md
+++ b/docs/features/008-fix-rubocop-array-brackets/brief.md
@@ -1,0 +1,49 @@
+# Бриф: Исправление нарушений Rubocop Layout/SpaceInsideArrayLiteralBrackets
+
+**Issue:** #8
+
+## Что делаем
+
+Исправляем 4 нарушения `Layout/SpaceInsideArrayLiteralBrackets` в двух файлах:
+
+- `lib/tasks/users.rake:3` — литерал `[:email, :password]`
+- `spec/mailers/passwords_mailer_spec.rb:10` — литерал `["test@example.com"]`
+
+Rubocop фиксирует по одному offense на каждую скобку литерала: 2 литерала × 2 скобки (открывающая + закрывающая) = 4 offenses.
+
+Проект использует `rubocop-rails-omakase`, правило требует пробелы внутри квадратных скобок (`[ :email, :password ]`). Приводим литералы к этому стилю.
+
+## Зачем
+
+Lint job в CI падает из-за этих предсуществующих нарушений. Это блокирует прохождение CI для любых PR, пока нарушения не устранены.
+
+## Границы
+
+**Входит:**
+- Правка литерала массива в `lib/tasks/users.rake:3`
+- Правка литерала массива в `spec/mailers/passwords_mailer_spec.rb:10`
+- Приведение файлов к соответствию `Layout/SpaceInsideArrayLiteralBrackets` из `rubocop-rails-omakase`
+
+**Вне границ:**
+- Исправление других cop'ов Rubocop, если они всплывут
+- Правка файлов за пределами двух указанных
+- Изменение конфигурации Rubocop (`.rubocop.yml`)
+- Изменение логики rake-задачи `users:create` и тестов `PasswordsMailer`
+- Любой рефакторинг, не связанный с расстановкой пробелов
+
+## Критерии приёмки
+
+- При запуске `bin/rubocop lib/tasks/users.rake spec/mailers/passwords_mailer_spec.rb` — 0 нарушений `Layout/SpaceInsideArrayLiteralBrackets`
+- При запуске `bin/rubocop` по всему проекту — количество offenses не увеличилось относительно `main` (для остальных cop'ов)
+- При запуске `bundle exec rspec spec/mailers/passwords_mailer_spec.rb` — все существующие тесты проходят
+- При запуске полного набора `bundle exec rspec` — регрессий нет
+- При выполнении lint job в CI на ветке фичи — job проходит успешно
+
+## Допущения
+
+- Допустимый способ правки — любой (ручной либо `bin/rubocop -a`), результат один и тот же — стиль `EnforcedStyle: space` из omakase
+- Других нарушений `Layout/SpaceInsideArrayLiteralBrackets` в проекте нет (issue явно называет только эти 4)
+
+## Открытые вопросы
+
+Нет.

--- a/docs/features/008-fix-rubocop-array-brackets/plan.md
+++ b/docs/features/008-fix-rubocop-array-brackets/plan.md
@@ -1,0 +1,189 @@
+# План реализации: Исправление нарушений Rubocop Layout/SpaceInsideArrayLiteralBrackets
+
+**Issue:** #8
+**Бриф:** [brief.md](brief.md)
+**Спецификация:** [spec.md](spec.md)
+
+## Обзор
+
+Задача стилистическая. Трогаем две строки в двух файлах, приводя литералы массива к `EnforcedStyle: space` из `rubocop-rails-omakase`. Никаких backend/frontend изменений, миграций и новых гемов.
+
+## Изменения Backend
+
+Только правка двух Ruby-литералов:
+
+- `lib/tasks/users.rake:3` — `[:email, :password]` → `[ :email, :password ]`
+- `spec/mailers/passwords_mailer_spec.rb:10` — `["test@example.com"]` → `[ "test@example.com" ]`
+
+## Изменения Frontend
+
+Не применимо.
+
+## Миграции
+
+Не применимо.
+
+## Зависимости / гемы
+
+Новые гемы не добавляются. Версии `rubocop-rails-omakase` и прочих в `Gemfile` / `Gemfile.lock` не меняются.
+
+## Способ правки
+
+Ручная правка (по одному пробелу после `[` и перед `]` в каждом литерале).
+
+**Обоснование выбора:** изменение затрагивает всего 2 строки, ручной способ детерминистичен, не требует предварительного `bundle install` и исключает риск, что автокорректор затронет что-то сверх целевых строк. Вариант `bin/rubocop -a --only Layout/SpaceInsideArrayLiteralBrackets` из спецификации остаётся допустимой альтернативой при необходимости.
+
+---
+
+## Шаги
+
+### Шаг 1. Установить зависимости
+
+**Вход:** чистая рабочая директория worktree, `bundle` установлен системно.
+**Выход:** установленные гемы, рабочий `bin/rubocop`.
+**Побочные эффекты:** изменений в репозитории нет (`Gemfile.lock` уже актуален).
+**Затрагиваемые файлы:** нет.
+**Команда:** `bundle install`
+**Способ проверки:** `bin/rubocop --version` отрабатывает без `Bundler::GemNotFound`.
+
+---
+
+### Шаг 2. Зафиксировать baseline количества offenses
+
+**Вход:** установленные гемы.
+**Выход:** известное число offenses по всему проекту до правки — `BASELINE_TOTAL`, и число offenses `Layout/SpaceInsideArrayLiteralBrackets` — `BASELINE_SPACE = 4` (ожидаемо).
+**Побочные эффекты:** нет.
+**Затрагиваемые файлы:** нет.
+**Команды:**
+- `bin/rubocop --format offenses` — сохранить суммарное число offenses (вывод целиком).
+- `bin/rubocop --only Layout/SpaceInsideArrayLiteralBrackets` — ожидаем 4 offenses в двух файлах из брифа.
+**Способ проверки:**
+- `BASELINE_SPACE == 4` и локации: `lib/tasks/users.rake:3` + `spec/mailers/passwords_mailer_spec.rb:10`.
+- Если число offenses или локации отличаются — возврат на этап 1 (бриф) с обновлением.
+
+---
+
+### Шаг 3. Правка `lib/tasks/users.rake:3`
+
+**Вход:** строка `[:email, :password]` на строке 3.
+**Выход:** строка `[ :email, :password ]` на той же позиции.
+**Побочные эффекты:** нет (семантика литерала не меняется).
+**Затрагиваемые файлы:** `lib/tasks/users.rake`.
+**Действие:** добавить пробел после `[` и перед `]` в литерале на строке 3.
+**Способ проверки:**
+- `bin/rubocop --only Layout/SpaceInsideArrayLiteralBrackets lib/tasks/users.rake` → 0 offenses.
+- `git diff lib/tasks/users.rake` показывает ровно одну изменённую строку.
+
+---
+
+### Шаг 4. Правка `spec/mailers/passwords_mailer_spec.rb:10`
+
+**Вход:** строка с `["test@example.com"]` на строке 10.
+**Выход:** строка с `[ "test@example.com" ]` на той же позиции.
+**Побочные эффекты:** нет (семантика литерала не меняется).
+**Затрагиваемые файлы:** `spec/mailers/passwords_mailer_spec.rb`.
+**Действие:** добавить пробел после `[` и перед `]` в литерале на строке 10.
+**Способ проверки:**
+- `bin/rubocop --only Layout/SpaceInsideArrayLiteralBrackets spec/mailers/passwords_mailer_spec.rb` → 0 offenses.
+- `git diff spec/mailers/passwords_mailer_spec.rb` показывает ровно одну изменённую строку.
+
+---
+
+### Шаг 5. Локальный прогон rubocop — целевой cop по двум файлам
+
+**Вход:** правки шагов 3 и 4 применены.
+**Выход:** подтверждение, что все 4 offenses устранены.
+**Побочные эффекты:** нет.
+**Затрагиваемые файлы:** нет.
+**Команда:** `bin/rubocop --only Layout/SpaceInsideArrayLiteralBrackets lib/tasks/users.rake spec/mailers/passwords_mailer_spec.rb`
+**Способ проверки:** exit code 0, вывод `no offenses detected`.
+
+---
+
+### Шаг 6. Локальный прогон rubocop — весь проект
+
+**Вход:** правки применены.
+**Выход:** суммарное число offenses по проекту `TOTAL_AFTER == BASELINE_TOTAL − 4`.
+**Побочные эффекты:** нет.
+**Затрагиваемые файлы:** нет.
+**Команды:**
+- `bin/rubocop --format offenses` — сравнить с baseline из шага 2.
+- `bin/rubocop --only Layout/SpaceInsideArrayLiteralBrackets` — ожидаем 0 offenses по всему проекту.
+**Способ проверки:**
+- Число offenses вне `Layout/SpaceInsideArrayLiteralBrackets` не выросло относительно baseline из шага 2.
+- `Layout/SpaceInsideArrayLiteralBrackets` показывает 0.
+- Если число offenses иных cop'ов выросло — останавливаемся, возврат на этап плана (границы требуют не трогать другие файлы).
+
+---
+
+### Шаг 7. Полный прогон rspec
+
+**Вход:** правки применены.
+**Выход:** отсутствие регрессий.
+**Побочные эффекты:** нет.
+**Затрагиваемые файлы:** нет.
+**Команда:** `bundle exec rspec`
+**Способ проверки:** 0 failures, 0 errors; число тестов не уменьшилось.
+
+---
+
+### Шаг 8. Коммит и push
+
+**Вход:** все локальные проверки пройдены.
+**Выход:** коммит на ветке `features/008-fix-rubocop-array-brackets`, запушенный в origin.
+**Побочные эффекты:** запуск CI на ветке.
+**Затрагиваемые файлы:** `lib/tasks/users.rake`, `spec/mailers/passwords_mailer_spec.rb` (+ SDD-артефакты из `docs/features/008-fix-rubocop-array-brackets/`).
+**Команды:**
+- `git add lib/tasks/users.rake spec/mailers/passwords_mailer_spec.rb docs/features/008-fix-rubocop-array-brackets/`
+- `git commit -m "fix: соблюсти Layout/SpaceInsideArrayLiteralBrackets в users.rake и passwords_mailer_spec"` (черновик; допустима адаптация под стиль репозитория)
+- `git push -u origin features/008-fix-rubocop-array-brackets`
+**Способ проверки:** `git status` чистый, ветка запушена.
+
+---
+
+### Шаг 9. Проверка CI
+
+**Вход:** запушенный коммит.
+**Выход:** зелёный lint job и зелёный полный pipeline.
+**Побочные эффекты:** нет.
+**Затрагиваемые файлы:** нет.
+**Команды:**
+- `gh run list --branch features/008-fix-rubocop-array-brackets --limit 1`
+- `gh run watch $(gh run list --branch features/008-fix-rubocop-array-brackets --limit 1 --json databaseId -q '.[0].databaseId')` (при необходимости)
+**Способ проверки:** все jobs (в т.ч. lint) завершаются с conclusion `success`.
+
+---
+
+### Шаг 10. Создание PR
+
+**Вход:** зелёный CI на ветке фичи.
+**Выход:** открытый PR `features/008-fix-rubocop-array-brackets` → `main` со ссылкой на issue #8.
+**Побочные эффекты:** внешнее действие, видимое другим участникам; запуск CI на PR.
+**Затрагиваемые файлы:** нет.
+**Команда:** `gh pr create --base main --head features/008-fix-rubocop-array-brackets --title "..." --body "..."` (title/body формируются на этапе приёмки; в теле — ссылка на issue #8).
+**Способ проверки:** PR создан, CI на PR зелёный, issue #8 привязан.
+
+---
+
+## Тестовая стратегия
+
+### Что тестируется
+
+| Уровень | Покрытие | Обоснование |
+|---------|----------|-------------|
+| **Lint (static)** | `bin/rubocop --only Layout/SpaceInsideArrayLiteralBrackets` по двум файлам и по всему проекту | Основная проверка — что правка устраняет нарушения и не вносит новых. |
+| **Lint (static, regression)** | `bin/rubocop --format offenses` до/после | Критерий приёмки: offenses по остальным cop'ам не выросли. |
+| **Regression (rspec suite)** | `bundle exec rspec` целиком | Отсутствие регрессий во всём проекте (включая `spec/mailers/passwords_mailer_spec.rb`). |
+| **CI (pipeline)** | GitHub Actions на ветке и на PR | Конечный критерий — lint job проходит. |
+
+### Что сознательно не покрыто тестами
+
+- **Новые unit-тесты для `users:create` и `PasswordsMailer`.** Правка чисто стилистическая: литералы `[:a, :b]` и `[ :a, :b ]` тождественны на уровне Ruby-парсера. Добавлять тесты на «не изменилась семантика» — работа без ценности, покрытие уже обеспечивается существующим `passwords_mailer_spec.rb` и прогоном всего rspec.
+- **Проверка на других стилистических cop'ах.** Вне границ фичи (см. бриф).
+- **Локальная проверка CI-воркфлоу (act / nektos).** CI исполняется на GitHub после push; дублирующая локальная эмуляция даёт лишнюю сложность без выигрыша.
+
+## Риски и откат
+
+- Если `bin/rubocop --format offenses` после правки покажет рост суммарного числа offenses — откатить изменения (`git restore <файлы>`), вернуться к шагу 3 и выяснить источник расхождения.
+- Если `bin/rubocop --only Layout/SpaceInsideArrayLiteralBrackets` после правки найдёт дополнительные нарушения за пределами двух целевых файлов — возврат на этап 1 (бриф) для расширения границ.
+- Если `rspec` упал после правки — противоречит инвариантам спецификации (семантика литерала не меняется); нужно остановиться и разбираться, а не править тесты.

--- a/docs/features/008-fix-rubocop-array-brackets/spec.md
+++ b/docs/features/008-fix-rubocop-array-brackets/spec.md
@@ -1,0 +1,86 @@
+# [APPROVED] Спецификация: Исправление нарушений Rubocop Layout/SpaceInsideArrayLiteralBrackets
+
+**Issue:** #8
+**Бриф:** [brief.md](brief.md)
+
+> **[Approved by @dniman 2026-04-19]**
+> Спецификация прошла ревью (уровень: quick).
+> Итераций: 1. Критичных замечаний: 0. Исправлено: 0.
+
+## Контекст
+
+`.rubocop.yml` наследует правила из `rubocop-rails-omakase`:
+
+```yaml
+inherit_gem: { rubocop-rails-omakase: rubocop.yml }
+```
+
+В omakase для `Layout/SpaceInsideArrayLiteralBrackets` включён `EnforcedStyle: space` — внутри квадратных скобок литерала массива должны быть пробелы.
+
+В двух файлах проекта стиль нарушен:
+
+- `lib/tasks/users.rake:3` — `[:email, :password]`
+- `spec/mailers/passwords_mailer_spec.rb:10` — `["test@example.com"]`
+
+Rubocop фиксирует 2 offenses на литерал (открывающая и закрывающая скобка) → 4 offenses суммарно. CI lint job падает из-за них.
+
+## Архитектурные решения
+
+Задача чисто стилистическая, архитектура не затрагивается.
+
+### Целевой формат
+
+- `lib/tasks/users.rake:3` → `[ :email, :password ]`
+- `spec/mailers/passwords_mailer_spec.rb:10` → `[ "test@example.com" ]`
+
+### Способ правки
+
+Допустимы оба варианта:
+
+- ручная правка (добавить по одному пробелу после `[` и перед `]`);
+- `bin/rubocop -a --only Layout/SpaceInsideArrayLiteralBrackets lib/tasks/users.rake spec/mailers/passwords_mailer_spec.rb`.
+
+Ограничение `--only` используется, чтобы автокорректор не зацепил другие cop'ы.
+
+### Границы изменений
+
+Трогаются ровно две строки в двух файлах. Никакие другие файлы, включая `.rubocop.yml`, `Gemfile`, `Gemfile.lock`, не модифицируются. Логика rake-задачи `users:create` и тестов `PasswordsMailer` не меняется — литерал `[:a, :b]` и `[ :a, :b ]` семантически идентичны.
+
+## Модели данных
+
+Не применимо.
+
+## Поведение UI
+
+Не применимо.
+
+## Edge cases
+
+1. **Локальный запуск rubocop невозможен без `bundle install`.**
+   На текущей машине `bin/rubocop` падает с `Bundler::GemNotFound: pagy-43.5.1`. Перед правкой/проверкой требуется выполнить `bundle install`.
+
+2. **Автокорректор меняет больше, чем ожидалось.**
+   Блокируется флагом `--only Layout/SpaceInsideArrayLiteralBrackets`. Если автокорректор всё же затронет что-то сверх двух целевых строк — такие изменения откатываются, правка остаётся в границах брифа.
+
+3. **В проекте появились новые нарушения того же cop'а, помимо известных двух.**
+   Бриф допускает, что их нет (пункт «Допущения»). Если прогон rubocop после правки покажет ненулевой остаток `Layout/SpaceInsideArrayLiteralBrackets` — возврат на этап 1 (бриф) с обновлением списка локаций.
+
+4. **Семантическое изменение литерала.**
+   Исключено: `[:a, :b]` и `[ :a, :b ]` — один и тот же Array-литерал для Ruby-парсера. Существующие тесты `PasswordsMailer` и rake-задача `users:create` после правки должны работать без изменений.
+
+5. **Расхождение версий rubocop-rails-omakase между локально и CI.**
+   Версия зафиксирована в `Gemfile.lock`, отдельно не меняется. Риск отсутствует, пока не трогаем Gemfile.
+
+## Соответствие критериям приёмки
+
+| Критерий из брифа | Как адресован |
+|---|---|
+| `bin/rubocop` по двум файлам — 0 нарушений `Layout/SpaceInsideArrayLiteralBrackets` | Целевой формат соответствует `EnforcedStyle: space` omakase |
+| `bin/rubocop` по всему проекту — offenses не выросли | Изменения локализованы двумя строками; автокорректор ограничен одним cop'ом |
+| `rspec spec/mailers/passwords_mailer_spec.rb` проходит | Литерал семантически не меняется |
+| Полный `rspec` — без регрессий | То же основание |
+| CI lint job на ветке — проходит | 4 известных offenses устраняются, новые не вносятся |
+
+## Открытые вопросы
+
+Нет.

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,6 +1,6 @@
 namespace :users do
   desc "Create a user: bin/rails 'users:create[email, password]'"
-  task :create, [:email, :password] => :environment do |_t, args|
+  task :create, [ :email, :password ] => :environment do |_t, args|
     User.create!(email_address: args[:email], password: args[:password])
     puts "User #{args[:email]} created."
   end

--- a/spec/mailers/passwords_mailer_spec.rb
+++ b/spec/mailers/passwords_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PasswordsMailer, type: :mailer do
     let(:mail) { PasswordsMailer.reset(user) }
 
     it "sends to the correct address" do
-      expect(mail.to).to eq(["test@example.com"])
+      expect(mail.to).to eq([ "test@example.com" ])
     end
 
     it "contains reset link" do


### PR DESCRIPTION
## Summary
- Привожу 2 литерала массива к стилю `EnforcedStyle: space` из `rubocop-rails-omakase` — устраняет 4 offenses, блокирующих lint job в CI.
- Затронуто 2 строки: `lib/tasks/users.rake:3` и `spec/mailers/passwords_mailer_spec.rb:10`.
- Семантика литералов не меняется.

Closes #8

## Test plan
- [x] `bin/rubocop --only Layout/SpaceInsideArrayLiteralBrackets` → 0 offenses (было 4)
- [x] `bin/rubocop --format offenses` → 0 (было 4)
- [x] `bundle exec rspec spec/mailers/passwords_mailer_spec.rb` → 3 examples, 0 failures
- [ ] Lint job в CI на PR — green
- [ ] Test job в CI ожидаемо красный из-за предсуществующей `Propshaft::MissingAssetError` (не связано с правкой, чинится отдельно в #9)